### PR TITLE
Go module support, golangci-lint linting.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,23 @@
+linters-settings:
+  gocyclo:
+    min-complexity: 25
+  govet:
+    check-shadowing: false
+  misspell:
+    locale: "US"
+
+linters:
+  enable-all: true
+  disable:
+    - stylecheck
+    - gosec
+    - dupl
+    - maligned
+    - depguard
+    - lll
+    - prealloc
+    - scopelint
+    - gocritic
+    - gochecknoinits
+    - gochecknoglobals
+    - typecheck # Go 1.13 incompatible pending new golangci-lint binary release

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ go:
   - "stable"
 
 install:
-  - go get golang.org/x/tools/cmd/cover
-  - go get github.com/mattn/goveralls
-  - go get github.com/kisielk/errcheck
-  - go get ./...
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
+  - GO111MODULE=off go get golang.org/x/tools/cmd/cover
+  - GO111MODULE=off go get github.com/mattn/goveralls
+  - go install -v ./...
 
 script:
-  - go vet ./...
-  - errcheck -exclude .errcheck_exclude ./...
+  - set -e
+  - golangci-lint run
   - go test -v -race -covermode=atomic -coverprofile=coverage.out ./...
-  - goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+  - goveralls -coverprofile=coverage.out -service=travis-ci

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/cpu/goacmedns
+
+go 1.12

--- a/storage_test.go
+++ b/storage_test.go
@@ -49,6 +49,9 @@ func TestNewFileStorage(t *testing.T) {
 	}
 
 	f, err := ioutil.TempFile("", "acmedns.account")
+	if err != nil {
+		t.Errorf("unexpected error creating tempfile: %v", err)
+	}
 	defer func() { _ = f.Close() }()
 
 	_, err = f.Write(testData)


### PR DESCRIPTION
* 40bc009 fixes an ineffectual assignment in `TestNewFileStorage` caught by `golangci-lint`.
* e6d0854 adds a `go.mod` to the project, cleans up Travis config, and switches to `golangci-lint` for linting.