### PR TITLE
fix: match JSON Account serialization to pyacmedns.

### DIFF
--- a/account.go
+++ b/account.go
@@ -4,8 +4,8 @@ package goacmedns
 // server. It represents an API username/key that can be used to update TXT
 // records for the account's subdomain.
 type Account struct {
-	FullDomain string
-	SubDomain  string
-	Username   string
-	Password   string
+	FullDomain string `json:"fulldomain"`
+	SubDomain  string `json:"subdomain"`
+	Username   string `json:"username"`
+	Password   string `json:"password"`
 }


### PR DESCRIPTION
Prior to this commit the `Account` objects marshalled to/from JSON by the `goacmedns` file storage used JSON keys with capitalization that differs from the `pyacmedns` JSON storage, and the register response from `acme-dns` (e.g. `Domain` vs `domain`).

This commit updates the `Account` type to add explicit `json` tags that ensure the capitalization of the fields matches that of `pyacmedns` and `acme-dns`. Go's JSON parsing semantics ensures legacy accounts with capitalized fields will still load without error.

Resolves https://github.com/cpu/goacmedns/issues/7