### PR TITLE
Add ProxyFromEnvironment to http client

### DIFF
--- a/client.go
+++ b/client.go
@@ -29,6 +29,7 @@ var (
 	// httpClient is a `http.Client` that is customized with the `defaultTimeout`
 	httpClient = http.Client{
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			Dial: (&net.Dialer{
 				Timeout:   defaultTimeout,
 				KeepAlive: defaultTimeout,


### PR DESCRIPTION
Currently trying to use this behind corporate proxy to ACMEDNS server on internet, and getting "dial tcp x.x.x.x:443 connect: connection refused"

Need to pick up https_proxy value and use it from environment variable in container/OS.