### PR TITLE
Store acme-dns API server URL alongisde of the rest of the Account details

### DIFF
--- a/account.go
+++ b/account.go
@@ -8,5 +8,7 @@ type Account struct {
 	SubDomain  string `json:"subdomain"`
 	Username   string `json:"username"`
 	Password   string `json:"password"`
-	Server     string `json:"server"`
+	// ServerURL contains the URL of the acme-dns server the Account was registered with 
+	// (may be empty for Account instances registered before this field was added).
+	ServerURL     string `json:"server_url"`
 }

--- a/account.go
+++ b/account.go
@@ -8,4 +8,5 @@ type Account struct {
 	SubDomain  string `json:"subdomain"`
 	Username   string `json:"username"`
 	Password   string `json:"password"`
+	Server     string `json:"server"`
 }

--- a/account.go
+++ b/account.go
@@ -8,7 +8,7 @@ type Account struct {
 	SubDomain  string `json:"subdomain"`
 	Username   string `json:"username"`
 	Password   string `json:"password"`
-	// ServerURL contains the URL of the acme-dns server the Account was registered with 
+	// ServerURL contains the URL of the acme-dns server the Account was registered with
 	// (may be empty for Account instances registered before this field was added).
-	ServerURL     string `json:"server_url"`
+	ServerURL string `json:"server_url"`
 }

--- a/client.go
+++ b/client.go
@@ -166,7 +166,7 @@ func (c Client) RegisterAccount(allowFrom []string) (Account, error) {
 	if err != nil {
 		return Account{}, fmt.Errorf("Failed to unmarshal account: %w", err)
 	}
-
+	acct.Server = c.baseURL
 	return acct, nil
 }
 

--- a/client.go
+++ b/client.go
@@ -166,7 +166,9 @@ func (c Client) RegisterAccount(allowFrom []string) (Account, error) {
 	if err != nil {
 		return Account{}, fmt.Errorf("Failed to unmarshal account: %w", err)
 	}
+
 	acct.Server = c.baseURL
+
 	return acct, nil
 }
 

--- a/client.go
+++ b/client.go
@@ -167,7 +167,7 @@ func (c Client) RegisterAccount(allowFrom []string) (Account, error) {
 		return Account{}, fmt.Errorf("Failed to unmarshal account: %w", err)
 	}
 
-	acct.Server = c.baseURL
+	acct.ServerURL = c.baseURL
 
 	return acct, nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -117,7 +117,7 @@ func TestRegisterAccount(t *testing.T) {
 				}
 			} else if tc.ExpectedErr == nil && err == nil {
 				// Needed to be able to assert equivalence, as the server addr is dynamic
-				tc.ExpectedAccount.Server = acct.Server
+				tc.ExpectedAccount.ServerURL = acct.ServerURL
 				if !reflect.DeepEqual(acct, *tc.ExpectedAccount) {
 					t.Errorf("expected account %v, got %v\n", tc.ExpectedAccount, acct)
 				}

--- a/client_test.go
+++ b/client_test.go
@@ -116,6 +116,8 @@ func TestRegisterAccount(t *testing.T) {
 					t.Errorf("expected err %#v, got %#v\n", tc.ExpectedErr, err)
 				}
 			} else if tc.ExpectedErr == nil && err == nil {
+				// Needed to be able to assert equivalence, as the server addr is dynamic
+				tc.ExpectedAccount.Server = acct.Server
 				if !reflect.DeepEqual(acct, *tc.ExpectedAccount) {
 					t.Errorf("expected account %v, got %v\n", tc.ExpectedAccount, acct)
 				}

--- a/storage_test.go
+++ b/storage_test.go
@@ -92,6 +92,9 @@ func TestNewFileStorage(t *testing.T) {
 
 func TestNewFileStorageWithLegacyData(t *testing.T) {
 	mode := os.FileMode(0600)
+	var legacyAcct, testAcct Account
+	var found bool
+
 	testData, err := json.Marshal(testLegacyAccount)
 	if err != nil {
 		t.Fatalf("unexpected error marshaling testAccounts: %v", err)
@@ -124,22 +127,23 @@ func TestNewFileStorageWithLegacyData(t *testing.T) {
 		t.Fatalf("expected a single account in the map, got %d", len(fs.accounts))
 	}
 
-	if legacyAcct, found := fs.accounts["threeletter.agency"]; !found {
+	if legacyAcct, found = fs.accounts["threeletter.agency"]; !found {
 		t.Fatalf("expected to find account but was unable to")
-	} else {
-		if legacyAcct.Server != "" {
-			t.Errorf("expected empty Server string from legacy account, but got %s", legacyAcct.Server)
-		} else {
-			if testAcct, found := testAccounts["threeletter.agency"]; !found {
-				t.Errorf("expected to find test account for threeletter.agency, but was unable to")
-			} else {
-				// set the missing value for legacy account to be able to evaluate equivelance
-				legacyAcct.Server = testAcct.Server
-				if !reflect.DeepEqual(legacyAcct, testAcct) {
-					t.Errorf("expected equivelant test and legacy accounts")
-				}
-			}
-		}
+	}
+
+	if legacyAcct.Server != "" {
+		t.Errorf("expected empty Server string from legacy account, but got %s", legacyAcct.Server)
+	}
+
+	if testAcct, found = testAccounts["threeletter.agency"]; !found {
+		t.Fatalf("expected to find test account for threeletter.agency, but was unable to")
+	}
+
+	// set the missing value for legacy account to be able to evaluate equivalence
+	legacyAcct.Server = testAcct.Server
+
+	if !reflect.DeepEqual(legacyAcct, testAcct) {
+		t.Errorf("expected equivalent test and legacy accounts")
 	}
 }
 

--- a/storage_test.go
+++ b/storage_test.go
@@ -15,14 +15,14 @@ var testAccounts = map[string]Account{
 		SubDomain:  "tossed.lettuceencrypt.org",
 		Username:   "cpu",
 		Password:   "hunter2",
-		Server:     "https://auth.acme-dns.io",
+		ServerURL:  "https://auth.acme-dns.io",
 	},
 	"threeletter.agency": {
 		FullDomain: "threeletter.agency",
 		SubDomain:  "jobs.threeletter.agency",
 		Username:   "spooky.mulder",
 		Password:   "trustno1",
-		Server:     "https://example.org",
+		ServerURL:  "https://example.org",
 	},
 }
 
@@ -134,8 +134,8 @@ func TestNewFileStorageWithLegacyData(t *testing.T) {
 		t.Fatalf("expected to find account but was unable to")
 	}
 
-	if legacyAcct.Server != "" {
-		t.Errorf("expected empty Server string from legacy account, but got %s", legacyAcct.Server)
+	if legacyAcct.ServerURL != "" {
+		t.Errorf("expected empty Server string from legacy account, but got %s", legacyAcct.ServerURL)
 	}
 
 	if testAcct, found = testAccounts["threeletter.agency"]; !found {
@@ -143,7 +143,7 @@ func TestNewFileStorageWithLegacyData(t *testing.T) {
 	}
 
 	// set the missing value for legacy account to be able to evaluate equivalence
-	legacyAcct.Server = testAcct.Server
+	legacyAcct.ServerURL = testAcct.ServerURL
 
 	if !reflect.DeepEqual(legacyAcct, testAcct) {
 		t.Errorf("expected equivalent test and legacy accounts")

--- a/storage_test.go
+++ b/storage_test.go
@@ -92,8 +92,11 @@ func TestNewFileStorage(t *testing.T) {
 
 func TestNewFileStorageWithLegacyData(t *testing.T) {
 	mode := os.FileMode(0600)
-	var legacyAcct, testAcct Account
-	var found bool
+
+	var (
+		legacyAcct, testAcct Account
+		found                bool
+	)
 
 	testData, err := json.Marshal(testLegacyAccount)
 	if err != nil {


### PR DESCRIPTION
This PR adds the functionality that stores the acme-dns API URL alongisde of the rest of the account information. The account information is dependant of the API server in question, so at least for me it makes sense.

The new functionality allows the storage to be self sufficient for all the required data points. While the API server URL can often be deducted from the account URL, it's not guaranteed.

The PR also adds  a test to ensure backwards compatibility with old storage format and to mitigate potential regressions in the backwards compatibility in the future.